### PR TITLE
Update ENTRYPOINT to CMD

### DIFF
--- a/container/processor.Dockerfile
+++ b/container/processor.Dockerfile
@@ -9,5 +9,4 @@ WORKDIR /app/live_data_processor
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
-WORKDIR /app/live_data_processor
-ENTRYPOINT ["python", "main.py"]
+CMD ["python", "main.py"]


### PR DESCRIPTION
Closes #27 

## Description
Change ENTRYPOINT to CMD to allow for overwriting of command if needed, and remove redundant WORKDIR
